### PR TITLE
feature(headers) allow header remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ var ProxyAdapter = require('rendr-proxy-adapter')
 
 var adapter = new ProxyAdapter({
     // forward the "Host" header
-    headers: ['host']
+    headers: [
+    	{name: 'host', as: 'x-original-host'},
+    	'Accept'
+    ]
 });
 
 rendr.createServer({

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,10 +55,20 @@ internals.getCookies = function (cookies, req) {
 internals.appendHeaders = function (headers, api, req) {
     _.each(headers, function (header) {
 
-        var value = req.headers[header];
+        var name;
+        var value;
 
-        if (value) {
-            api.headers[header] = value;
+
+        if (_.isObject(header)) {
+            value = req.headers[header.name];
+            name = header.as;
+        } else {
+            value = req.headers[header];
+            name = header;
+        }
+
+        if (value && name) {
+            api.headers[name] = value;
         }
 
     });

--- a/test/index.js
+++ b/test/index.js
@@ -169,7 +169,7 @@ lab.experiment('Rendr proxy adapter', function () {
     lab.test('keeps the selected request headers', function (done) {
 
         var adapter = new ProxyAdapter({
-            headers: ['host']
+            headers: [{name: 'host', as: 'x-original-host'}]
         });
 
         var api = {
@@ -184,9 +184,10 @@ lab.experiment('Rendr proxy adapter', function () {
 
         var output = adapter.apiDefaults(api, req);
 
-        Code.expect(output.headers).to.include('host');
+        Code.expect(output.headers).to.include('x-original-host');
+        Code.expect(output.headers).to.not.include('host');
         Code.expect(output.headers).to.not.include('hostname');
-        Code.expect(output.headers['host']).to.equal('localhost:1337');
+        Code.expect(output.headers['x-original-host']).to.equal('localhost:1337');
 
         return done();
     });


### PR DESCRIPTION
This PR adds support to remap header names.
e.g.

``` javascript
var adapter = new ProxyAdapter({
    // forward the "Host" header
    headers: [
        {name: 'host', as: 'x-original-host'},
        'Header-2',
        'Header-3'
    ]
});
```
